### PR TITLE
Edit location of auto-progress button

### DIFF
--- a/GameEngine.cs
+++ b/GameEngine.cs
@@ -542,7 +542,7 @@ namespace clickerheroes.autoplayer
             CandyHeight = (int)(PlayableArea.Height * 0.05);
 
             ProgressButton.X = (int)(PlayableArea.Width * 0.9799 + PlayableArea.Left);
-            ProgressButton.Y = (int)(PlayableArea.Height * 0.3308 + PlayableArea.Top);
+            ProgressButton.Y = (int)(PlayableArea.Height * 0.3908 + PlayableArea.Top); //edited from .3308 because of new "log-in" button
 
             AscendButton.X = (int)(PlayableArea.Width * 0.4344 + PlayableArea.Left);
             AscendButton.Y = (int)(PlayableArea.Height * 0.6654 + PlayableArea.Top);


### PR DESCRIPTION
The location of this button was moved down in a recent patch to make room for a log-in button. This should change to the new location.